### PR TITLE
feat: Implement PDF parser and display page

### DIFF
--- a/Components/Layout/NavMenu.razor
+++ b/Components/Layout/NavMenu.razor
@@ -4,6 +4,7 @@
     <MudNavLink Href="counter" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Add">Counter</MudNavLink>
     
     <MudNavLink Href="weather" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.List">Weather</MudNavLink>
+    <MudNavLink Href="parser" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Search">Parser</MudNavLink>
 
 </MudNavMenu>
 

--- a/Components/Models/PickingList.cs
+++ b/Components/Models/PickingList.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+
+namespace PdfParserTest.Components.Models
+{
+    public class PickingList
+    {
+        public string? OrderNumber { get; set; }
+        public string? CustomerName { get; set; }
+        public List<Product> Products { get; set; } = new List<Product>();
+    }
+
+    public class Product
+    {
+        public string? Sku { get; set; }
+        public string? Description { get; set; }
+        public int Quantity { get; set; }
+    }
+}

--- a/Components/Pages/Parser.razor
+++ b/Components/Pages/Parser.razor
@@ -1,0 +1,64 @@
+@page "/parser"
+@using PdfParserTest.Components.Models
+@using PdfParserTest.Components.Services
+@inject PdfParsingService PdfParsingService
+
+<h3>PDF Parser</h3>
+
+<MudSelect T="string" Label="Select a PDF file" @bind-Value="selectedPdf">
+    @foreach (var file in samplePdfs)
+    {
+        <MudSelectItem T="string" Value="@file">@file</MudSelectItem>
+    }
+</MudSelect>
+
+<MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="ParsePdf">Parse PDF</MudButton>
+
+@if (pickingList != null)
+{
+    <h4>Picking List</h4>
+    <p><strong>Order Number:</strong> @pickingList.OrderNumber</p>
+    <p><strong>Customer Name:</strong> @pickingList.CustomerName</p>
+
+    <h5>Products</h5>
+    <MudTable Items="@pickingList.Products" Hover="true" Striped="true">
+        <HeaderContent>
+            <MudTh>SKU</MudTh>
+            <MudTh>Description</MudTh>
+            <MudTh>Quantity</MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd DataLabel="SKU">@context.Sku</MudTd>
+            <MudTd DataLabel="Description">@context.Description</MudTd>
+            <MudTd DataLabel="Quantity">@context.Quantity</MudTd>
+        </RowTemplate>
+    </MudTable>
+}
+
+@code {
+    private string selectedPdf;
+    private PickingList? pickingList;
+    private List<string> samplePdfs = new List<string>();
+
+    protected override void OnInitialized()
+    {
+        var sampleFiles = System.IO.Directory.GetFiles("Samples", "*.pdf");
+        foreach (var file in sampleFiles)
+        {
+            samplePdfs.Add(System.IO.Path.GetFileName(file));
+        }
+        if(samplePdfs.Count > 0)
+        {
+            selectedPdf = samplePdfs[0];
+        }
+    }
+
+    private void ParsePdf()
+    {
+        if (!string.IsNullOrEmpty(selectedPdf))
+        {
+            var filePath = System.IO.Path.Combine("Samples", selectedPdf);
+            pickingList = PdfParsingService.ParsePickingList(filePath);
+        }
+    }
+}

--- a/Components/Services/PdfParsingService.cs
+++ b/Components/Services/PdfParsingService.cs
@@ -1,0 +1,68 @@
+using UglyToad.PdfPig;
+using PdfParserTest.Components.Models;
+using System.Text.RegularExpressions;
+using System.Globalization;
+
+namespace PdfParserTest.Components.Services
+{
+    public class PdfParsingService
+    {
+        public PickingList ParsePickingList(string filePath)
+        {
+            using (PdfDocument document = PdfDocument.Open(filePath))
+            {
+                string fullText = "";
+                foreach (var page in document.GetPages())
+                {
+                    fullText += page.Text;
+                }
+
+                var pickingList = new PickingList();
+                var lines = fullText.Split('\n');
+
+                // Find Order Number
+                var orderNumberLine = lines.FirstOrDefault(l => l.Contains("No."));
+                if (orderNumberLine != null)
+                {
+                    var match = Regex.Match(orderNumberLine, @"No\.(\d+)");
+                    if (match.Success)
+                    {
+                        pickingList.OrderNumber = match.Groups[1].Value;
+                    }
+                }
+
+                // Find Customer Name
+                var buyerLineIndex = Array.FindIndex(lines, l => l.Contains("BUYER"));
+                if (buyerLineIndex != -1 && buyerLineIndex + 1 < lines.Length)
+                {
+                    pickingList.CustomerName = lines[buyerLineIndex + 1].Trim();
+                }
+
+                // Find Products
+                var productLinesStartIndex = Array.FindIndex(lines, l => l.Contains("LINE    QUANTITY"));
+                if (productLinesStartIndex != -1)
+                {
+                    for (int i = productLinesStartIndex + 1; i < lines.Length; i++)
+                    {
+                        var line = lines[i];
+                        if (line.Contains("----------")) break;
+
+                        var match = Regex.Match(line, @"(\d+)\s+([\d,]+)\s+LBS\s+.*\s+([A-Z0-9/]+)\s+");
+                        if (match.Success)
+                        {
+                            var product = new Product
+                            {
+                                Sku = match.Groups[3].Value,
+                                Description = line.Substring(match.Index + match.Length).Trim(),
+                                Quantity = int.Parse(match.Groups[2].Value, NumberStyles.AllowThousands)
+                            };
+                            pickingList.Products.Add(product);
+                        }
+                    }
+                }
+
+                return pickingList;
+            }
+        }
+    }
+}

--- a/PdfParserTest.csproj
+++ b/PdfParserTest.csproj
@@ -9,5 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="MudBlazor" Version="8.*" />
+    <PackageReference Include="PdfPig" Version="0.1.11" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This commit introduces a new feature that allows parsing "Picking List" PDF files and displaying the extracted information on a new Razor page.

Key changes:
- Added the `PdfPig` NuGet package for PDF text extraction.
- Created a `PdfParsingService` to handle the parsing logic using regular expressions.
- Added `PickingList` and `Product` models to represent the parsed data.
- Created a new `/parser` Razor page with a UI to select a sample PDF and display the parsed data.
- Added a link to the new page in the navigation menu.