### PR TITLE
feat: Implement PDF parser and display page

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,5 +1,6 @@
 using MudBlazor.Services;
 using PdfParserTest.Components;
+using PdfParserTest.Components.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -9,6 +10,7 @@ builder.Services.AddMudServices();
 // Add services to the container.
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
+builder.Services.AddTransient<PdfParsingService>();
 
 var app = builder.Build();
 


### PR DESCRIPTION
This commit introduces a new feature that allows parsing "Picking List" PDF files and displaying the extracted information on a new Razor page.

Key changes:
- Added the `PdfPig` NuGet package for PDF text extraction.
- Created a `PdfParsingService` to handle the parsing logic using regular expressions.
- Added `PickingList` and `Product` models to represent the parsed data.
- Created a new `/parser` Razor page with a UI to select a sample PDF and display the parsed data.
- Added a link to the new page in the navigation menu.
- Registered the `PdfParsingService` for dependency injection.