### PR TITLE
feat: Add download functionality for parsed text

### DIFF
--- a/Components/App.razor
+++ b/Components/App.razor
@@ -16,6 +16,7 @@
     <Routes @rendermode="InteractiveServer" />
     <script src="_framework/blazor.web.js"></script>
     <script src=@Assets["_content/MudBlazor/MudBlazor.min.js"]></script>
+    <script src="js/download.js"></script>
 </body>
 
 </html>

--- a/Components/Pages/Parser.razor
+++ b/Components/Pages/Parser.razor
@@ -1,6 +1,7 @@
 @page "/parser"
 @using PdfParserTest.Components.Services
 @inject PdfParsingService PdfParsingService
+@inject IJSRuntime JSRuntime
 
 <h3>PDF Parser</h3>
 
@@ -15,6 +16,7 @@
 
 @if (!string.IsNullOrEmpty(rawText))
 {
+    <MudButton Variant="Variant.Filled" Color="Color.Secondary" OnClick="DownloadText">Download Text</MudButton>
     <h4>Raw Text</h4>
     <pre>@rawText</pre>
 }
@@ -43,6 +45,15 @@
         {
             var filePath = System.IO.Path.Combine("Samples", selectedPdf);
             rawText = PdfParsingService.GetRawText(filePath);
+        }
+    }
+
+    private async Task DownloadText()
+    {
+        if (!string.IsNullOrEmpty(rawText))
+        {
+            var fileName = $"{System.IO.Path.GetFileNameWithoutExtension(selectedPdf)}.txt";
+            await JSRuntime.InvokeVoidAsync("downloadFile", fileName, rawText);
         }
     }
 }

--- a/wwwroot/js/download.js
+++ b/wwwroot/js/download.js
@@ -1,0 +1,8 @@
+function downloadFile(fileName, fileContent) {
+    var link = document.createElement('a');
+    link.href = 'data:text/plain;charset=utf-8,' + encodeURIComponent(fileContent);
+    link.download = fileName;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+}


### PR DESCRIPTION
This commit adds the ability to download the raw text extracted from a PDF file. A "Download" button is now available on the parser page after a PDF has been parsed.

Key changes:
- Added a JavaScript helper function to trigger file downloads.
- Updated the `Parser.razor` page to include a "Download" button and the logic to call the JavaScript function.
- Injected `IJSRuntime` into the `Parser.razor` page to enable JavaScript interop.